### PR TITLE
eslint and json5 version bumps + eslint rule fix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,10 +14,7 @@
   },
   "rules": {
     "import/order": "warn",
-    "@typescript-eslint/no-confusing-void-expression": [
-      "error",
-      { "ignoreArrowShorthand": true }
-    ]
+    "@typescript-eslint/no-confusing-void-expression": "off"
   },
   "ignorePatterns": ["/dist/"]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,11 @@
     "project": "./lint.tsconfig.json"
   },
   "rules": {
-    "import/order": "warn"
+    "import/order": "warn",
+    "@typescript-eslint/no-confusing-void-expression": [
+      "error",
+      { "ignoreArrowShorthand": true }
+    ]
   },
   "ignorePatterns": ["/dist/"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "eslint": "^8.30.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-config-standard": "^17.0.0",
-        "eslint-config-standard-with-typescript": "^24.0.0",
+        "eslint-config-standard-with-typescript": "^26.0.0",
         "eslint-plugin-import": "^2.26.0",
         "mocha": "^10.2.0",
         "prettier": "^2.8.1",
@@ -2450,9 +2450,9 @@
       }
     },
     "node_modules/eslint-config-standard-with-typescript": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-24.0.0.tgz",
-      "integrity": "sha512-vEnGXZ5aiR1enl9652iIP4nTpY3GPcNEwuhrsPbKO3Ce3D6T3yCqZdkUPk8nJetfdL/yO0DLsHg2d/l9iECIdg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-26.0.0.tgz",
+      "integrity": "sha512-TluIWunQo76qp4MHyYIaTT+sN2q2v/jTeE3Dj4rXsSbx27GOUEOujhJaAL3v9dHVQelAK13gZ5Jy9IWnWCyFrg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/parser": "^5.0.0",
@@ -3758,9 +3758,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -6972,9 +6972,9 @@
       "requires": {}
     },
     "eslint-config-standard-with-typescript": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-24.0.0.tgz",
-      "integrity": "sha512-vEnGXZ5aiR1enl9652iIP4nTpY3GPcNEwuhrsPbKO3Ce3D6T3yCqZdkUPk8nJetfdL/yO0DLsHg2d/l9iECIdg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-26.0.0.tgz",
+      "integrity": "sha512-TluIWunQo76qp4MHyYIaTT+sN2q2v/jTeE3Dj4rXsSbx27GOUEOujhJaAL3v9dHVQelAK13gZ5Jy9IWnWCyFrg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/parser": "^5.0.0",
@@ -7918,9 +7918,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint": "^8.30.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-standard": "^17.0.0",
-    "eslint-config-standard-with-typescript": "^24.0.0",
+    "eslint-config-standard-with-typescript": "^26.0.0",
     "eslint-plugin-import": "^2.26.0",
     "mocha": "^10.2.0",
     "prettier": "^2.8.1",

--- a/src/build.ts
+++ b/src/build.ts
@@ -78,11 +78,11 @@ const fetchAndUnpack = async function (platarch: Platarch): Promise<void> {
 };
 
 const tarx = async function (inputStream: Readable): Promise<void> {
-  await new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     // We can pipe the fetch response straight to tar
     const sink = inputStream.pipe(tar.x({ C: binDirectory }));
 
-    sink.on("finish", () => resolve(undefined));
+    sink.on("finish", () => resolve());
     sink.on("error", (err: Error) => reject(err));
   });
 };

--- a/src/build.ts
+++ b/src/build.ts
@@ -78,11 +78,11 @@ const fetchAndUnpack = async function (platarch: Platarch): Promise<void> {
 };
 
 const tarx = async function (inputStream: Readable): Promise<void> {
-  return await new Promise((resolve, reject) => {
+  await new Promise((resolve, reject) => {
     // We can pipe the fetch response straight to tar
     const sink = inputStream.pipe(tar.x({ C: binDirectory }));
 
-    sink.on("finish", () => resolve());
+    sink.on("finish", () => resolve(undefined));
     sink.on("error", (err: Error) => reject(err));
   });
 };


### PR DESCRIPTION
Here are some upgrades that dependabot could not automatically handle. typescript-eslint had two major version bumps requiring us to manually update some config and code formatting.  json5 which is a peer dependency needed a specific change to package-lock in order to fix a [high severity vulnerability(]https://github.com/advisories/GHSA-9c47-m6qq-7p4h)