### PR TITLE
Workflow Updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,10 @@
 name: Publish
 on:
-  push:
-    tags:
-      - "*"
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Version of this release"
+        required: true
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -24,6 +26,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 18
+
+      - name: Tag release
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{ github.event.inputs.release_version }}
+          message: "Release ${{ github.event.inputs.release_version }}"
+      
+      - name: Update version in package.json
+        id: version-bump
+        uses: jaywcjlove/github-action-package@v1.3.0
+        with:
+          version: ${{ github.event.inputs.release_version }}
 
       - name: Install 🔧
         run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 name: Publish
 on:
+  pull_request:
+    types: [opened, reopened]
   workflow_dispatch:
     inputs:
       release_version:
@@ -12,62 +14,62 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
 
-      - name: Cache 📦
-        uses: actions/cache@v1
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+      # - name: Cache 📦
+      #   uses: actions/cache@v1
+      #   with:
+      #     path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
 
-      - name: Setup Node Environment ⬢
-        uses: actions/setup-node@v1
-        with:
-          node-version: 18
+      # - name: Setup Node Environment ⬢
+      #   uses: actions/setup-node@v1
+      #   with:
+      #     node-version: 18
 
-      - name: Tag release
-        uses: rickstaa/action-create-tag@v1
-        with:
-          tag: ${{ github.event.inputs.release_version }}
-          message: "Release ${{ github.event.inputs.release_version }}"
+      # - name: Tag release
+      #   uses: rickstaa/action-create-tag@v1
+      #   with:
+      #     tag: ${{ github.event.inputs.release_version }}
+      #     message: "Release ${{ github.event.inputs.release_version }}"
       
-      - name: Update version in package.json
-        id: version-bump
-        uses: jaywcjlove/github-action-package@v1.3.0
-        with:
-          version: ${{ github.event.inputs.release_version }}
+      # - name: Update version in package.json
+      #   id: version-bump
+      #   uses: jaywcjlove/github-action-package@v1.3.0
+      #   with:
+      #     version: ${{ github.event.inputs.release_version }}
 
-      - name: Install 🔧
-        run: npm install
+      # - name: Install 🔧
+      #   run: npm install
 
-      - name: Latest
-        id: tag
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      # - name: Latest
+      #   id: tag
+      #   run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
-      - name: Conditional
-        id: cond
-        uses: haya14busa/action-cond@v1
-        with:
-          cond: ${{ contains(steps.tag.outputs.tag, '-') }}
-          if_true: "next"
-          if_false: "latest"
+      # - name: Conditional
+      #   id: cond
+      #   uses: haya14busa/action-cond@v1
+      #   with:
+      #     cond: ${{ contains(steps.tag.outputs.tag, '-') }}
+      #     if_true: "next"
+      #     if_false: "latest"
 
-      - name: Publish 📦
-        id: publish
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_AUTH_TOKEN }}
-          tag: ${{ steps.cond.outputs.value }}
-          access: public
-          check-version: true
+      # - name: Publish 📦
+      #   id: publish
+      #   uses: JS-DevTools/npm-publish@v1
+      #   with:
+      #     token: ${{ secrets.NPM_AUTH_TOKEN }}
+      #     tag: ${{ steps.cond.outputs.value }}
+      #     access: public
+      #     check-version: true
 
-      - name: Release
-        if: steps.publish.outputs.type != 'none'
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.publish.outputs.version }}
-          generateReleaseNotes: true
-          prerelease: ${{ contains(steps.publish.outputs.type, 'pre') }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Release
+      #   if: steps.publish.outputs.type != 'none'
+      #   uses: ncipollo/release-action@v1
+      #   with:
+      #     tag: ${{ steps.publish.outputs.version }}
+      #     generateReleaseNotes: true
+      #     prerelease: ${{ contains(steps.publish.outputs.type, 'pre') }}
+      #     token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,5 @@
 name: Publish
 on:
-  pull_request:
-    types: [opened, reopened]
   workflow_dispatch:
     inputs:
       release_version:
@@ -14,62 +12,62 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
 
-      # - name: Cache 📦
-      #   uses: actions/cache@v1
-      #   with:
-      #     path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-build-${{ env.cache-name }}-
-      #       ${{ runner.os }}-build-
-      #       ${{ runner.os }}-
+      - name: Cache 📦
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
 
-      # - name: Setup Node Environment ⬢
-      #   uses: actions/setup-node@v1
-      #   with:
-      #     node-version: 18
+      - name: Setup Node Environment ⬢
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
 
-      # - name: Tag release
-      #   uses: rickstaa/action-create-tag@v1
-      #   with:
-      #     tag: ${{ github.event.inputs.release_version }}
-      #     message: "Release ${{ github.event.inputs.release_version }}"
+      - name: Tag release
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{ github.event.inputs.release_version }}
+          message: "Release ${{ github.event.inputs.release_version }}"
       
-      # - name: Update version in package.json
-      #   id: version-bump
-      #   uses: jaywcjlove/github-action-package@v1.3.0
-      #   with:
-      #     version: ${{ github.event.inputs.release_version }}
+      - name: Update version in package.json
+        id: version-bump
+        uses: jaywcjlove/github-action-package@v1.3.0
+        with:
+          version: ${{ github.event.inputs.release_version }}
 
-      # - name: Install 🔧
-      #   run: npm install
+      - name: Install 🔧
+        run: npm install
 
-      # - name: Latest
-      #   id: tag
-      #   run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: Latest
+        id: tag
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
-      # - name: Conditional
-      #   id: cond
-      #   uses: haya14busa/action-cond@v1
-      #   with:
-      #     cond: ${{ contains(steps.tag.outputs.tag, '-') }}
-      #     if_true: "next"
-      #     if_false: "latest"
+      - name: Conditional
+        id: cond
+        uses: haya14busa/action-cond@v1
+        with:
+          cond: ${{ contains(steps.tag.outputs.tag, '-') }}
+          if_true: "next"
+          if_false: "latest"
 
-      # - name: Publish 📦
-      #   id: publish
-      #   uses: JS-DevTools/npm-publish@v1
-      #   with:
-      #     token: ${{ secrets.NPM_AUTH_TOKEN }}
-      #     tag: ${{ steps.cond.outputs.value }}
-      #     access: public
-      #     check-version: true
+      - name: Publish 📦
+        id: publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_AUTH_TOKEN }}
+          tag: ${{ steps.cond.outputs.value }}
+          access: public
+          check-version: true
 
-      # - name: Release
-      #   if: steps.publish.outputs.type != 'none'
-      #   uses: ncipollo/release-action@v1
-      #   with:
-      #     tag: ${{ steps.publish.outputs.version }}
-      #     generateReleaseNotes: true
-      #     prerelease: ${{ contains(steps.publish.outputs.type, 'pre') }}
-      #     token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        if: steps.publish.outputs.type != 'none'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.publish.outputs.version }}
+          generateReleaseNotes: true
+          prerelease: ${{ contains(steps.publish.outputs.type, 'pre') }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validator-update-pr.yml
+++ b/.github/workflows/validator-update-pr.yml
@@ -3,8 +3,6 @@
 # this to run when there is a release of the Validator.
 name: Validator Update PR
 on:
-  pull_request:
-    types: [opened, reopened]
   workflow_dispatch:
     inputs:
       validator_version:
@@ -18,76 +16,76 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
-      # - name: Cache 📦
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-build-${{ env.cache-name }}-
-      #       ${{ runner.os }}-build-
-      #       ${{ runner.os }}-
+      - name: Cache 📦
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
 
-      # - name: Setup Node Environment ⬢
-      #   uses: actions/setup-node@v3
-      #   with:
-      #     node-version: 18
+      - name: Setup Node Environment ⬢
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
 
-      # - name: Update validatorVersion in package.json
-      #   id: validator-version-bump
-      #   uses: jaywcjlove/github-action-package@v1.3.0
-      #   with:
-      #     data: |
-      #       {
-      #         "validatorVersion": "${{ github.event.inputs.validator_version }}"
-      #       }
+      - name: Update validatorVersion in package.json
+        id: validator-version-bump
+        uses: jaywcjlove/github-action-package@v1.3.0
+        with:
+          data: |
+            {
+              "validatorVersion": "${{ github.event.inputs.validator_version }}"
+            }
 
-      # - run: echo "validator version - ${{ steps.info.outputs.version }} - ${{ github.event.inputs.validator_version }}"
+      - run: echo "validator version - ${{ steps.info.outputs.version }} - ${{ github.event.inputs.validator_version }}"
 
-      # - name: Install 🔧
-      #   run: npm install
+      - name: Install 🔧
+        run: npm install
 
-      # - name: Build 🔧
-      #   run: npm run build
+      - name: Build 🔧
+        run: npm run build
 
-      # - name: Commit files from the build
-      #   run: |
-      #     git config --local user.name  ${{ github.actor }}
-      #     npm run prettier:fix
-      #     git add --all
-      #     git commit -m "Validator version update for ${{ github.event.inputs.validator_version }}"
+      - name: Commit files from the build
+        run: |
+          git config --local user.name  ${{ github.actor }}
+          npm run prettier:fix
+          git add --all
+          git commit -m "Validator version update for ${{ github.event.inputs.validator_version }}"
 
-      # - name: Push changes
-      #   uses: ad-m/github-push-action@master
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     branch: validator-update-pr-${{ github.event.inputs.validator_version }}
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: validator-update-pr-${{ github.event.inputs.validator_version }}
 
-      # - uses: actions/github-script@v6
-      #   id: create-validator-update-pr
-      #   name: Create Validator Update PR
-      #   with:
-      #     # NOTE: The automatic release workflow uses ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
-      #     #       so that workflows can be triggered across repos.
-      #     github-token: ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
-      #     script: |
-      #       try {
-      #         const version = '${{ github.event.inputs.validator_version }}';
-      #         const branchName = 'validator-update-pr-' + version;
-      #         const baseBranch = 'main';
-      #         const prBody = '✅ This PR was created by the Validator Update PR action for version ' + version;
+      - uses: actions/github-script@v6
+        id: create-validator-update-pr
+        name: Create Validator Update PR
+        with:
+          # NOTE: The automatic release workflow uses ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
+          #       so that workflows can be triggered across repos.
+          github-token: ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
+          script: |
+            try {
+              const version = '${{ github.event.inputs.validator_version }}';
+              const branchName = 'validator-update-pr-' + version;
+              const baseBranch = 'main';
+              const prBody = '✅ This PR was created by the Validator Update PR action for version ' + version;
 
-      #         // Create a pull request
-      #         await github.rest.pulls.create({
-      #           owner: context.repo.owner,
-      #           repo: context.repo.repo,
-      #           title: 'Release PR ' + version,
-      #           head: branchName,
-      #           base: baseBranch,
-      #           body: prBody
-      #         });
-      #       } catch (err) {
-      #         console.log(err);
-      #         core.setFailed('Failed to create release branch: ' + err.message);
-      #         return;
-      #       }
+              // Create a pull request
+              await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Release PR ' + version,
+                head: branchName,
+                base: baseBranch,
+                body: prBody
+              });
+            } catch (err) {
+              console.log(err);
+              core.setFailed('Failed to create release branch: ' + err.message);
+              return;
+            }

--- a/.github/workflows/validator-update-pr.yml
+++ b/.github/workflows/validator-update-pr.yml
@@ -79,7 +79,7 @@ jobs:
               await github.rest.pulls.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: 'Release PR ' + version,
+                title: 'Validator Update PR ' + version,
                 head: branchName,
                 base: baseBranch,
                 body: prBody

--- a/.github/workflows/validator-update-pr.yml
+++ b/.github/workflows/validator-update-pr.yml
@@ -5,12 +5,12 @@ name: Release PR
 on:
   workflow_dispatch:
     inputs:
-      release_version:
-        description: "Version of this release"
+      validator_version:
+        description: "Validator version"
         required: true
 
 jobs:
-  release-pr:
+  validator-update-pr:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -37,10 +37,10 @@ jobs:
         with:
           data: |
             {
-              "validatorVersion": "${{ github.event.inputs.release_version }}"
+              "validatorVersion": "${{ github.event.inputs.validator_version }}"
             }
 
-      - run: echo "validator version - ${{ steps.info.outputs.version }} - ${{ github.event.inputs.release_version }}"
+      - run: echo "validator version - ${{ steps.info.outputs.version }} - ${{ github.event.inputs.validator_version }}"
 
       - name: Install 🔧
         run: npm install
@@ -53,40 +53,34 @@ jobs:
           git config --local user.name  ${{ github.actor }}
           npm run prettier:fix
           git add --all
-          git commit -m "Release PR commit for ${{ github.event.inputs.release_version }}"
+          git commit -m "Validator version update for ${{ github.event.inputs.validator_version }}"
 
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: release-pr-${{ github.event.inputs.release_version }}
-
-      - name: Tag release
-        uses: rickstaa/action-create-tag@v1
-        with:
-          tag: ${{ github.event.inputs.release_version }}
-          message: "Validator Release ${{ github.event.inputs.release_version }}"
+          branch: validator-update-pr-${{ github.event.inputs.validator_version }}
 
       - uses: actions/github-script@v6
-        id: create-release-pr
-        name: Create Release PR
+        id: create-validator-update-pr
+        name: Create Validator Update PR
         with:
           # NOTE: The automatic release workflow uses ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
           #       so that workflows can be triggered across repos.
           github-token: ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
           script: |
             try {
-              const tag = '${{ github.event.inputs.release_version }}';
-              const releaseBranchName = 'release-pr-' + tag;
+              const version = '${{ github.event.inputs.validator_version }}';
+              const branchName = 'validator-update-pr-' + version;
               const baseBranch = 'main';
-              const prBody = '✅ This PR was created by the Release PR action for version ' + tag;
+              const prBody = '✅ This PR was created by the Validator Update PR action for version ' + version;
 
               // Create a pull request
               await github.rest.pulls.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: 'Release PR ' + tag,
-                head: releaseBranchName,
+                title: 'Release PR ' + version,
+                head: branchName,
                 base: baseBranch,
                 body: prBody
               });

--- a/.github/workflows/validator-update-pr.yml
+++ b/.github/workflows/validator-update-pr.yml
@@ -42,12 +42,6 @@ jobs:
 
       - run: echo "validator version - ${{ steps.info.outputs.version }} - ${{ github.event.inputs.validator_version }}"
 
-      - name: Install 🔧
-        run: npm install
-
-      - name: Build 🔧
-        run: npm run build
-
       - name: Commit files from the build
         run: |
           git config --local user.name  ${{ github.actor }}

--- a/.github/workflows/validator-update-pr.yml
+++ b/.github/workflows/validator-update-pr.yml
@@ -1,7 +1,7 @@
 # The can be run manually via the github website if needed.
 # Normally the go-tableland repo will run an action that triggers
 # this to run when there is a release of the Validator.
-name: Release PR
+name: Validator Update PR
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/validator-update-pr.yml
+++ b/.github/workflows/validator-update-pr.yml
@@ -3,6 +3,8 @@
 # this to run when there is a release of the Validator.
 name: Validator Update PR
 on:
+  pull_request:
+    types: [opened, reopened]
   workflow_dispatch:
     inputs:
       validator_version:
@@ -16,76 +18,76 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
-      - name: Cache 📦
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+      # - name: Cache 📦
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
 
-      - name: Setup Node Environment ⬢
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
+      # - name: Setup Node Environment ⬢
+      #   uses: actions/setup-node@v3
+      #   with:
+      #     node-version: 18
 
-      - name: Update validatorVersion in package.json
-        id: validator-version-bump
-        uses: jaywcjlove/github-action-package@v1.3.0
-        with:
-          data: |
-            {
-              "validatorVersion": "${{ github.event.inputs.validator_version }}"
-            }
+      # - name: Update validatorVersion in package.json
+      #   id: validator-version-bump
+      #   uses: jaywcjlove/github-action-package@v1.3.0
+      #   with:
+      #     data: |
+      #       {
+      #         "validatorVersion": "${{ github.event.inputs.validator_version }}"
+      #       }
 
-      - run: echo "validator version - ${{ steps.info.outputs.version }} - ${{ github.event.inputs.validator_version }}"
+      # - run: echo "validator version - ${{ steps.info.outputs.version }} - ${{ github.event.inputs.validator_version }}"
 
-      - name: Install 🔧
-        run: npm install
+      # - name: Install 🔧
+      #   run: npm install
 
-      - name: Build 🔧
-        run: npm run build
+      # - name: Build 🔧
+      #   run: npm run build
 
-      - name: Commit files from the build
-        run: |
-          git config --local user.name  ${{ github.actor }}
-          npm run prettier:fix
-          git add --all
-          git commit -m "Validator version update for ${{ github.event.inputs.validator_version }}"
+      # - name: Commit files from the build
+      #   run: |
+      #     git config --local user.name  ${{ github.actor }}
+      #     npm run prettier:fix
+      #     git add --all
+      #     git commit -m "Validator version update for ${{ github.event.inputs.validator_version }}"
 
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: validator-update-pr-${{ github.event.inputs.validator_version }}
+      # - name: Push changes
+      #   uses: ad-m/github-push-action@master
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     branch: validator-update-pr-${{ github.event.inputs.validator_version }}
 
-      - uses: actions/github-script@v6
-        id: create-validator-update-pr
-        name: Create Validator Update PR
-        with:
-          # NOTE: The automatic release workflow uses ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
-          #       so that workflows can be triggered across repos.
-          github-token: ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
-          script: |
-            try {
-              const version = '${{ github.event.inputs.validator_version }}';
-              const branchName = 'validator-update-pr-' + version;
-              const baseBranch = 'main';
-              const prBody = '✅ This PR was created by the Validator Update PR action for version ' + version;
+      # - uses: actions/github-script@v6
+      #   id: create-validator-update-pr
+      #   name: Create Validator Update PR
+      #   with:
+      #     # NOTE: The automatic release workflow uses ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
+      #     #       so that workflows can be triggered across repos.
+      #     github-token: ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
+      #     script: |
+      #       try {
+      #         const version = '${{ github.event.inputs.validator_version }}';
+      #         const branchName = 'validator-update-pr-' + version;
+      #         const baseBranch = 'main';
+      #         const prBody = '✅ This PR was created by the Validator Update PR action for version ' + version;
 
-              // Create a pull request
-              await github.rest.pulls.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: 'Release PR ' + version,
-                head: branchName,
-                base: baseBranch,
-                body: prBody
-              });
-            } catch (err) {
-              console.log(err);
-              core.setFailed('Failed to create release branch: ' + err.message);
-              return;
-            }
+      #         // Create a pull request
+      #         await github.rest.pulls.create({
+      #           owner: context.repo.owner,
+      #           repo: context.repo.repo,
+      #           title: 'Release PR ' + version,
+      #           head: branchName,
+      #           base: baseBranch,
+      #           body: prBody
+      #         });
+      #       } catch (err) {
+      #         console.log(err);
+      #         core.setFailed('Failed to create release branch: ' + err.message);
+      #         return;
+      #       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/validator",
-  "version": "0.0.1-alpha-3",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/validator",
-      "version": "0.0.1-alpha-3",
+      "version": "0.0.0",
       "license": "MIT AND Apache-2.0",
       "devDependencies": {
         "@tableland/local": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/validator",
-  "version": "0.0.1-alpha-3",
+  "version": "0.0.0",
   "validatorVersion": "0.0.1-alpha-3",
   "description": "tableland validator binary repository",
   "publishConfig": {


### PR DESCRIPTION
Updated the publish and validator pr workflows to be consistent with what we discussed on voice chat. Was able to test them using the `gh` cli, you can see the results here:

Validator update workflow for a fictional validator version `2.0`:
https://github.com/tablelandnetwork/js-validator/actions/runs/3896408758

Publish workflow for version `0.0.0-pre.5`:
https://github.com/tablelandnetwork/js-validator/actions/runs/3896457424
https://github.com/tablelandnetwork/js-validator/releases/tag/0.0.0-pre.5
https://www.npmjs.com/package/@tableland/validator?activeTab=versions

