### PR TITLE
Add package.json files for each build dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "files": [
     "bin/**/*",
     "dist/**/*.js?(.map)",
+    "dist/**/*.json",
     "dist/**/*.d.ts",
     "src/**/*.ts"
   ],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "files": [
     "bin/**/*",
     "dist/**/*.js?(.map)",
-    "dist/**/*.json",
+    "dist/**/package.json",
     "dist/**/*.d.ts",
     "src/**/*.ts"
   ],


### PR DESCRIPTION
The published package wasn't including the package.json files that are specific to each build module type, which may have been causing down stream issues.  This PR will instruct npm to include those files when this package is published.