### PR TITLE
update @tableland/local dev-dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT AND Apache-2.0",
       "devDependencies": {
-        "@tableland/local": "^0.0.5",
+        "@tableland/local": "^1.0.0",
         "@types/decompress": "^4.2.4",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.11.17",
@@ -874,18 +874,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -921,73 +909,24 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@spruceid/siwe-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
-      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
-      "dev": true,
-      "dependencies": {
-        "@noble/hashes": "^1.1.2",
-        "apg-js": "^4.1.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      }
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "dev": true
-    },
-    "node_modules/@stablelib/binary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
-      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
-      "dev": true,
-      "dependencies": {
-        "@stablelib/int": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/int": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
-      "dev": true
-    },
-    "node_modules/@stablelib/random": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
-      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
-      "dev": true,
-      "dependencies": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/wipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
-      "dev": true
-    },
     "node_modules/@tableland/evm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-3.0.3.tgz",
-      "integrity": "sha512-Ci8QJubb6Z4ipPANALqAPQ9byh0tsRWZREej8QXGqLfHRqCAJfnMRTy2f47Oqq7IQ6Ajcy5holeUr9EtSmXNXA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
+      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@tableland/local": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-0.0.5.tgz",
-      "integrity": "sha512-KAChShClp1MYfRr1jjVBO9VkfHvB9T/7bNBdeLjwwimyeOGqiu4WPzV5Ud/vuJ2qJa8q0KKEv+BAHLNbVyQ2qQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.0.0.tgz",
+      "integrity": "sha512-1IHlY8Ma0zxUP+Z/uY5OfA4BSjjXSzDymO1dOaAdkA11naVZ/wQS0FI16gb1IYCo3JxvIM8NY9oCWRdLlMh/zg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@tableland/sdk": "^3.1.5",
-        "@tableland/validator": "^0.0.2",
+        "@tableland/sdk": "^4.0.0-pre.5",
+        "@tableland/validator": "^1.0.0",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -1016,9 +955,9 @@
       }
     },
     "node_modules/@tableland/local/node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -1043,25 +982,26 @@
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-3.1.5.tgz",
-      "integrity": "sha512-iq+1bsdxNDEGXFgEYAEYdPYjitkvqn4Y6r7B1eOUQmQ3GBErEaWUZfp9XI/CG6K/ZLmkpLettG9FF8FNNA52dA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.1.tgz",
+      "integrity": "sha512-ScVsLS/da0xtLUwBx0pd9+5SLgdpMYwFPfL3CYidkRnO37Jikx2Z1pmkeT6JMawTovo/t3pKuN8RBxLigxxQpQ==",
       "dev": true,
       "dependencies": {
-        "@stablelib/base64": "^1.0.1",
-        "@tableland/evm": "^3.0.0",
-        "camelcase": "^6.3.0",
-        "ethers": "^5.6.9",
-        "siwe": "^2.0.5"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "@tableland/evm": "^4.0.0",
+        "@tableland/sqlparser": "^1.0.4",
+        "ethers": "^5.7.2"
       }
     },
+    "node_modules/@tableland/sqlparser": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.4.tgz",
+      "integrity": "sha512-T9EieFjxLb9327nF5HhL5/bYBt7GFL3CgzxJeyU3tjGaQdi/0FQi6/z/jv3jG9pXkAed65lmntHNSHDhkUPjOQ==",
+      "dev": true
+    },
     "node_modules/@tableland/validator": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-0.0.2.tgz",
-      "integrity": "sha512-CykQIihLfujH5d+S6we2Kg86gu2MLaTFLorBiXe4Tgq3QjovSLjPk5ahR0VKy50L8Kvk8U2MUErz2V9Mw7Hy1A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.0.tgz",
+      "integrity": "sha512-ZzryZ+oIE/eOWLRpZrkmws26tJcssKW8RTfAIJ1nsLF6uTM7M4WDSXCVvTvXwnjk4fpPk+F6OiAUG9hSLmupmQ==",
       "dev": true
     },
     "node_modules/@tsconfig/node10": {
@@ -1632,12 +1572,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/apg-js": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.1.2.tgz",
-      "integrity": "sha512-2OALKUe82NLVPe4NTooom8NykWIa2D7YxO7jG1pgnYWnkfhTUriXpITmLvVD8k8TzDfa9G5O4y8rPe2/uUB1Bg==",
-      "dev": true
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -4732,21 +4666,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/siwe": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
-      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
-      "dev": true,
-      "dependencies": {
-        "@spruceid/siwe-parser": "^2.0.2",
-        "@stablelib/random": "^1.0.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      },
-      "peerDependencies": {
-        "ethers": "^5.5.1"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5149,12 +5068,6 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
-    },
-    "node_modules/valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==",
-      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -5850,12 +5763,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "@noble/hashes": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
-      "dev": true
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5882,69 +5789,20 @@
         "fastq": "^1.6.0"
       }
     },
-    "@spruceid/siwe-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
-      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
-      "dev": true,
-      "requires": {
-        "@noble/hashes": "^1.1.2",
-        "apg-js": "^4.1.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      }
-    },
-    "@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "dev": true
-    },
-    "@stablelib/binary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
-      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
-      "dev": true,
-      "requires": {
-        "@stablelib/int": "^1.0.1"
-      }
-    },
-    "@stablelib/int": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
-      "dev": true
-    },
-    "@stablelib/random": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
-      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
-      "dev": true,
-      "requires": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/wipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
-      "dev": true
-    },
     "@tableland/evm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-3.0.3.tgz",
-      "integrity": "sha512-Ci8QJubb6Z4ipPANALqAPQ9byh0tsRWZREej8QXGqLfHRqCAJfnMRTy2f47Oqq7IQ6Ajcy5holeUr9EtSmXNXA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
+      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA==",
       "dev": true
     },
     "@tableland/local": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-0.0.5.tgz",
-      "integrity": "sha512-KAChShClp1MYfRr1jjVBO9VkfHvB9T/7bNBdeLjwwimyeOGqiu4WPzV5Ud/vuJ2qJa8q0KKEv+BAHLNbVyQ2qQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.0.0.tgz",
+      "integrity": "sha512-1IHlY8Ma0zxUP+Z/uY5OfA4BSjjXSzDymO1dOaAdkA11naVZ/wQS0FI16gb1IYCo3JxvIM8NY9oCWRdLlMh/zg==",
       "dev": true,
       "requires": {
-        "@tableland/sdk": "^3.1.5",
-        "@tableland/validator": "^0.0.2",
+        "@tableland/sdk": "^4.0.0-pre.5",
+        "@tableland/validator": "^1.0.0",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -5964,9 +5822,9 @@
           }
         },
         "yargs": {
-          "version": "17.6.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-          "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+          "version": "17.7.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
           "dev": true,
           "requires": {
             "cliui": "^8.0.1",
@@ -5987,22 +5845,26 @@
       }
     },
     "@tableland/sdk": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-3.1.5.tgz",
-      "integrity": "sha512-iq+1bsdxNDEGXFgEYAEYdPYjitkvqn4Y6r7B1eOUQmQ3GBErEaWUZfp9XI/CG6K/ZLmkpLettG9FF8FNNA52dA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.1.tgz",
+      "integrity": "sha512-ScVsLS/da0xtLUwBx0pd9+5SLgdpMYwFPfL3CYidkRnO37Jikx2Z1pmkeT6JMawTovo/t3pKuN8RBxLigxxQpQ==",
       "dev": true,
       "requires": {
-        "@stablelib/base64": "^1.0.1",
-        "@tableland/evm": "^3.0.0",
-        "camelcase": "^6.3.0",
-        "ethers": "^5.6.9",
-        "siwe": "^2.0.5"
+        "@tableland/evm": "^4.0.0",
+        "@tableland/sqlparser": "^1.0.4",
+        "ethers": "^5.7.2"
       }
     },
+    "@tableland/sqlparser": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.4.tgz",
+      "integrity": "sha512-T9EieFjxLb9327nF5HhL5/bYBt7GFL3CgzxJeyU3tjGaQdi/0FQi6/z/jv3jG9pXkAed65lmntHNSHDhkUPjOQ==",
+      "dev": true
+    },
     "@tableland/validator": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-0.0.2.tgz",
-      "integrity": "sha512-CykQIihLfujH5d+S6we2Kg86gu2MLaTFLorBiXe4Tgq3QjovSLjPk5ahR0VKy50L8Kvk8U2MUErz2V9Mw7Hy1A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.0.tgz",
+      "integrity": "sha512-ZzryZ+oIE/eOWLRpZrkmws26tJcssKW8RTfAIJ1nsLF6uTM7M4WDSXCVvTvXwnjk4fpPk+F6OiAUG9hSLmupmQ==",
       "dev": true
     },
     "@tsconfig/node10": {
@@ -6380,12 +6242,6 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "apg-js": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.1.2.tgz",
-      "integrity": "sha512-2OALKUe82NLVPe4NTooom8NykWIa2D7YxO7jG1pgnYWnkfhTUriXpITmLvVD8k8TzDfa9G5O4y8rPe2/uUB1Bg==",
-      "dev": true
     },
     "arg": {
       "version": "4.1.3",
@@ -8655,18 +8511,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "siwe": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
-      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
-      "dev": true,
-      "requires": {
-        "@spruceid/siwe-parser": "^2.0.2",
-        "@stablelib/random": "^1.0.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      }
-    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8977,12 +8821,6 @@
           }
         }
       }
-    },
-    "valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==",
-      "dev": true
     },
     "which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT AND Apache-2.0",
       "devDependencies": {
-        "@tableland/local": "^1.0.0",
+        "@tableland/local": "^1.1.0",
         "@types/decompress": "^4.2.4",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.11.17",
@@ -910,23 +910,23 @@
       }
     },
     "node_modules/@tableland/evm": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
-      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.1.0.tgz",
+      "integrity": "sha512-1/qIewZo5//2egVxZwjZyo8TySDGzlF8swdxMjvPeVVx9OJprT8ttF8nJmMtKIBNK0b4HkvW/qA2AqP8cOGcQg==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@tableland/local": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.0.0.tgz",
-      "integrity": "sha512-1IHlY8Ma0zxUP+Z/uY5OfA4BSjjXSzDymO1dOaAdkA11naVZ/wQS0FI16gb1IYCo3JxvIM8NY9oCWRdLlMh/zg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.1.0.tgz",
+      "integrity": "sha512-3M6Qqt3D6yudF0JZauRB4fJa7tLXWpewrIliQhLdsxNVbBOQpsQ1WHZ9fLJqoV0yqBREE9gFzEiDjSjSunX9Mw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@tableland/sdk": "^4.0.0-pre.5",
-        "@tableland/validator": "^1.0.0",
+        "@tableland/sdk": "^4.0.2",
+        "@tableland/validator": "^1.1.0",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -982,26 +982,26 @@
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.1.tgz",
-      "integrity": "sha512-ScVsLS/da0xtLUwBx0pd9+5SLgdpMYwFPfL3CYidkRnO37Jikx2Z1pmkeT6JMawTovo/t3pKuN8RBxLigxxQpQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.2.tgz",
+      "integrity": "sha512-3Tpoiff6kfq2CzKx/7LUcFpydBfCvkOIvpaMbyjz0b7HVVsMFA2uj6CaevPYV1uP/W7Ncn/ytXwys5MtMp9SNw==",
       "dev": true,
       "dependencies": {
-        "@tableland/evm": "^4.0.0",
-        "@tableland/sqlparser": "^1.0.4",
+        "@tableland/evm": "^4.1.0",
+        "@tableland/sqlparser": "^1.0.5",
         "ethers": "^5.7.2"
       }
     },
     "node_modules/@tableland/sqlparser": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.4.tgz",
-      "integrity": "sha512-T9EieFjxLb9327nF5HhL5/bYBt7GFL3CgzxJeyU3tjGaQdi/0FQi6/z/jv3jG9pXkAed65lmntHNSHDhkUPjOQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.5.tgz",
+      "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg==",
       "dev": true
     },
     "node_modules/@tableland/validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.0.tgz",
-      "integrity": "sha512-ZzryZ+oIE/eOWLRpZrkmws26tJcssKW8RTfAIJ1nsLF6uTM7M4WDSXCVvTvXwnjk4fpPk+F6OiAUG9hSLmupmQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.1.0.tgz",
+      "integrity": "sha512-eaz8C5k4kQa8NLxrYM17i778bFbw124iTKgwnJhBbkRTQ0+KOcq2tUWAgzCk5pmpGZz5Tfy40sD7UcbfRDlDfg==",
       "dev": true
     },
     "node_modules/@tsconfig/node10": {
@@ -5790,19 +5790,19 @@
       }
     },
     "@tableland/evm": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.0.0.tgz",
-      "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.1.0.tgz",
+      "integrity": "sha512-1/qIewZo5//2egVxZwjZyo8TySDGzlF8swdxMjvPeVVx9OJprT8ttF8nJmMtKIBNK0b4HkvW/qA2AqP8cOGcQg==",
       "dev": true
     },
     "@tableland/local": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.0.0.tgz",
-      "integrity": "sha512-1IHlY8Ma0zxUP+Z/uY5OfA4BSjjXSzDymO1dOaAdkA11naVZ/wQS0FI16gb1IYCo3JxvIM8NY9oCWRdLlMh/zg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-1.1.0.tgz",
+      "integrity": "sha512-3M6Qqt3D6yudF0JZauRB4fJa7tLXWpewrIliQhLdsxNVbBOQpsQ1WHZ9fLJqoV0yqBREE9gFzEiDjSjSunX9Mw==",
       "dev": true,
       "requires": {
-        "@tableland/sdk": "^4.0.0-pre.5",
-        "@tableland/validator": "^1.0.0",
+        "@tableland/sdk": "^4.0.2",
+        "@tableland/validator": "^1.1.0",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
         "ethers": "^5.7.2",
@@ -5845,26 +5845,26 @@
       }
     },
     "@tableland/sdk": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.1.tgz",
-      "integrity": "sha512-ScVsLS/da0xtLUwBx0pd9+5SLgdpMYwFPfL3CYidkRnO37Jikx2Z1pmkeT6JMawTovo/t3pKuN8RBxLigxxQpQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.0.2.tgz",
+      "integrity": "sha512-3Tpoiff6kfq2CzKx/7LUcFpydBfCvkOIvpaMbyjz0b7HVVsMFA2uj6CaevPYV1uP/W7Ncn/ytXwys5MtMp9SNw==",
       "dev": true,
       "requires": {
-        "@tableland/evm": "^4.0.0",
-        "@tableland/sqlparser": "^1.0.4",
+        "@tableland/evm": "^4.1.0",
+        "@tableland/sqlparser": "^1.0.5",
         "ethers": "^5.7.2"
       }
     },
     "@tableland/sqlparser": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.4.tgz",
-      "integrity": "sha512-T9EieFjxLb9327nF5HhL5/bYBt7GFL3CgzxJeyU3tjGaQdi/0FQi6/z/jv3jG9pXkAed65lmntHNSHDhkUPjOQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.5.tgz",
+      "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg==",
       "dev": true
     },
     "@tableland/validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.0.0.tgz",
-      "integrity": "sha512-ZzryZ+oIE/eOWLRpZrkmws26tJcssKW8RTfAIJ1nsLF6uTM7M4WDSXCVvTvXwnjk4fpPk+F6OiAUG9hSLmupmQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.1.0.tgz",
+      "integrity": "sha512-eaz8C5k4kQa8NLxrYM17i778bFbw124iTKgwnJhBbkRTQ0+KOcq2tUWAgzCk5pmpGZz5Tfy40sD7UcbfRDlDfg==",
       "dev": true
     },
     "@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "MIT AND Apache-2.0",
   "devDependencies": {
-    "@tableland/local": "^1.0.0",
+    "@tableland/local": "^1.1.0",
     "@types/decompress": "^4.2.4",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.11.17",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "MIT AND Apache-2.0",
   "devDependencies": {
-    "@tableland/local": "^0.0.5",
+    "@tableland/local": "^1.0.0",
     "@types/decompress": "^4.2.4",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.11.17",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,32 +1,47 @@
 import { strictEqual, deepStrictEqual } from "assert";
 import { describe, test } from "mocha";
-import { getAccounts, getConnection } from "@tableland/local";
+import { getAccounts, getDatabase, getValidator } from "@tableland/local";
 
 describe("index", function () {
   this.timeout(25000);
   // Note that we're using the second account here
   const [, signer] = getAccounts();
-  const sdk = getConnection(signer);
+  const sdk = getDatabase(signer);
+  const validator = getValidator();
 
   test("create", async function () {
-    const { name } = await sdk.create("counter integer", { prefix: "table" });
-    strictEqual(name, "table_31337_2");
+    const { meta } = await sdk
+      .prepare("create table my_table (counter integer);")
+      .all();
+    strictEqual(meta.txn?.name, "my_table_31337_2");
   });
 
   test("insert", async function () {
-    const { hash } = await sdk.write("insert into table_31337_2 values (1);");
-    const txnReceipt = await sdk.receipt(hash);
+    const { meta } = await sdk
+      .prepare("insert into my_table_31337_2 values (1);")
+      .all();
+    const txnReceipt = await validator.receiptByTransactionHash({
+      chainId: 31337,
+      transactionHash: meta.txn?.transactionHash ?? "",
+    });
     strictEqual(txnReceipt?.chainId, 31337);
   });
 
   test("update", async function () {
-    const { hash } = await sdk.write("update table_31337_2 set counter=2;");
-    const txnReceipt = await sdk.receipt(hash);
+    const { meta } = await sdk
+      .prepare("update my_table_31337_2 set counter=2;")
+      .all();
+    const txnReceipt = await validator.receiptByTransactionHash({
+      chainId: 31337,
+      transactionHash: meta.txn?.transactionHash ?? "",
+    });
     strictEqual(txnReceipt?.chainId, 31337);
   });
 
   test("query", async function () {
-    const { rows } = await sdk.read("select * from table_31337_2;");
-    deepStrictEqual(rows[0], [2]);
+    const { results } = await sdk
+      .prepare("select * from my_table_31337_2;")
+      .all();
+    deepStrictEqual(results, [{ counter: 2 }]);
   });
 });


### PR DESCRIPTION
This updates the tests for this package to use the most recent `@tableland/local` package, which will be necessary to prevent breakage when the go-tableland build without the JSON RPC API is released.