### PR TITLE
Add arm64 to build script

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -87,8 +87,9 @@ const fetchAndUnpack = async function (platarch: Platarch): Promise<void> {
   const filename = platarch.name.includes("windows")
     ? platarch.name + ".exe"
     : platarch.name;
-  // all of the unzipped/extracted downloads expand to a single file named `api`
-  shelljs.mv(join(binDirectory, "api"), join(binDirectory, filename));
+  const binName = platarch.name.includes("windows") ? "api.exe" : "api";
+  // all of the unzipped/extracted downloads expand to a single file named `api` except window, which is `api.exe`
+  shelljs.mv(join(binDirectory, binName), join(binDirectory, filename));
 };
 
 const tarx = async function (inputStream: Readable): Promise<void> {

--- a/src/build.ts
+++ b/src/build.ts
@@ -26,14 +26,21 @@ const platarchs: Platarch[] = [
     filetype: ".tar.gz",
   },
   {
+    name: "darwin-arm64",
+    filetype: ".tar.gz",
+  },
+  {
     name: "linux-amd64",
+    filetype: ".tar.gz",
+  },
+  {
+    name: "linux-arm64",
     filetype: ".tar.gz",
   },
   {
     name: "windows-amd64",
     filetype: ".zip",
   },
-  // TODO: add M1 build if/when that makes sense
 ];
 
 const binDirectory = join(_dirname, "..", "..", "bin");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
+// aside from holding the compiled binaries to run a validator for all of our supported systems
+// this repo's main functionality is to expose the full path to the binary for the system that
+// loaded this file
+
 import { resolve } from "node:path";
-// TODO: aside from holding the compiled binaries to run a validator for all of our supported systems
-//       this repo's only functionality is to expose the full path to the binary for the system that
-//       loaded this file
 // NOTE: We are creating this file in the prebuild.sh script so that we can support cjs and esm
 import { getDirname } from "./module-specific.js";
 const _dirname = getDirname();


### PR DESCRIPTION
#Overview
This adds the arm64 builds to the build script.
related to https://github.com/tablelandnetwork/go-tableland/pull/536
#Details
The go-tableland repo is now able to build and release binaries for arm64 archs.  When the issue described in https://github.com/tablelandnetwork/go-tableland/issues/535 is worked out, the changes in this PR will be needed to include the arm binaries in this package.